### PR TITLE
Ensure stale callbacks are removed from CallbackQueue

### DIFF
--- a/src/CallbackQueue.cpp
+++ b/src/CallbackQueue.cpp
@@ -7,9 +7,17 @@
 // Singleton instance
 CallbackQueue CallbackQueue::instance;
 
-void CallbackQueue::queueCallback(Callback cb)
+void CallbackQueue::CallbackOwner::queueCallback(Callback cb)
 {
-	instance.queue.push_back(cb);
+	instance.queue.push_back({this, cb});
+}
+
+CallbackQueue::CallbackOwner::~CallbackOwner()
+{
+	std::erase_if(
+		instance.queue,
+		[this](CallbackEntry entry)
+		{ return entry.owner == this; });
 }
 
 void CallbackQueue::handleQueue()
@@ -23,7 +31,7 @@ void CallbackQueue::handleQueue()
 	{
 		try
 		{
-			instance.queue[i]();
+			instance.queue[i].cb();
 		}
 		catch (const AbortWorkException &e)
 		{

--- a/src/CallbackQueue.hpp
+++ b/src/CallbackQueue.hpp
@@ -15,14 +15,35 @@ class CallbackQueue
 {
 public:
 	using Callback = std::function<void()>;
-	static void queueCallback(Callback cb);
 	static void handleQueue();
+
+	/*
+		Owner class for callbacks added to queue.
+		All callbacks must be queued through an owner.
+		The owner removes pending callbacks from the queue on destruction.
+
+		The owner is identified by its address, so it is not copyable or movable.
+	*/
+	class CallbackOwner
+	{
+	public:
+		CallbackOwner() = default;
+		~CallbackOwner();
+		CallbackOwner(const CallbackOwner &) = delete;
+		CallbackOwner &operator=(const CallbackOwner &) = delete;
+
+		void queueCallback(CallbackQueue::Callback cb);
+	};
 
 private:
 	CallbackQueue() = default;
 	CallbackQueue(const CallbackQueue &other) = delete;
 	CallbackQueue &operator=(const CallbackQueue &other) = delete;
 
-	std::vector<Callback> queue;
+	struct CallbackEntry {
+		CallbackOwner *owner;
+		Callback cb;
+	};
+	std::vector<CallbackEntry> queue;
 	static CallbackQueue instance;
 };

--- a/src/ClientHandler.cpp
+++ b/src/ClientHandler.cpp
@@ -9,7 +9,6 @@
 #include <string>
 #include <utility>
 
-#include "CallbackQueue.hpp"
 #include "Config.hpp"
 #include "ErrorRequestHandler.hpp"
 #include "RequestHeader.hpp"
@@ -285,7 +284,7 @@ void ClientHandler::updateWakeup()
 	{
 		// Queue callback to handle buffered data
 		bufferedDataCallbackPending = true;
-		CallbackQueue::queueCallback(
+		cbOwner.queueCallback(
 			[this]()
 			{
 				bufferedDataCallback();

--- a/src/ClientHandler.hpp
+++ b/src/ClientHandler.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "AbortWorkException.hpp"
+#include "CallbackQueue.hpp"
 #include "ChunkHeaderReader.hpp"
 #include "Config.hpp"
 #include "RequestHeaderReader.hpp"
@@ -42,6 +43,7 @@ public:
 
 private:
 	const ListenerConfig &config;
+	CallbackQueue::CallbackOwner cbOwner;
 
 	/* IO handling and buffering */
 


### PR DESCRIPTION
All callbacks are now queued through an owner object. Destruction of owner removes entries from the queue so that callbacks are never called on destructed objects. Of course, user of queue must still be careful if the function accesses other objects not tied to callback owner lifetime.

Fixes #34.