### PR TITLE
fix: Content-Type for file requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ SRCS := $(addprefix $(SRCDIR)/,\
 	AutoindexRequestHandler.cpp \
 	DeleteRequestHandler.cpp \
 	Utils.cpp \
+	MimeTypes.cpp \
 )
 
 # Project targets

--- a/src/FileRequestHandler.cpp
+++ b/src/FileRequestHandler.cpp
@@ -1,4 +1,5 @@
 #include "FileRequestHandler.hpp"
+#include "MimeTypes.hpp"
 
 #include <cstddef>
 #include <span>
@@ -77,7 +78,7 @@ void FileRequestHandler::start(const char *filePath)
 	bytesRemaining_ = st.st_size;
 	std::string header =
 		"HTTP/1.1 200 OK\r\n"
-		"Content-Type: application/octet-stream\r\n"
+		"Content-Type: " + MimeTypes::getType(filePath) + "\r\n"
 		"Content-Length: " +
 		std::to_string(st.st_size) +
 		"\r\n\r\n";

--- a/src/MimeTypes.cpp
+++ b/src/MimeTypes.cpp
@@ -1,0 +1,57 @@
+#include "MimeTypes.hpp"
+
+#include <cctype>
+#include <cstddef>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include "Utils.hpp"
+
+MimeTypes MimeTypes::instance;
+
+MimeTypes::MimeTypes()
+{
+	const char *path = "/etc/mime.types";
+	std::ifstream file(path);
+
+	// If file is missing, we just silently start with an empty map (defaults to octet-stream)
+	if (!file.is_open())
+		return;
+
+	std::string line;
+	while (std::getline(file, line))
+	{
+		if (line.empty() || line[0] == '#')
+			continue;
+
+		std::stringstream ss(line);
+		std::string mimeType;
+		ss >> mimeType; // First word: "text/html"
+
+		std::string extension;
+		while (ss >> extension) // Next words: "html", "htm", "shtml"
+			extensionToType[extension] = mimeType;
+	}
+}
+
+MimeTypes::~MimeTypes()
+{
+}
+
+static std::string getExtension(const std::string &filename)
+{
+	size_t pos = filename.rfind('.');
+	if (pos == std::string::npos || pos == filename.length() - 1)
+		return "";
+	return toLower(filename.substr(pos + 1));
+}
+
+std::string MimeTypes::getType(const std::string &filename)
+{
+	std::string ext = getExtension(filename);
+
+	if (instance.extensionToType.contains(ext))
+		return instance.extensionToType[ext];
+	return "application/octet-stream";
+}

--- a/src/MimeTypes.hpp
+++ b/src/MimeTypes.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <string>
+#include <map>
+
+class MimeTypes
+{
+public:
+	/*
+		Returns the MIME type for a given filename (e.g., "image/png" for "file.png").
+		Defaults to "application/octet-stream" if unknown.
+	*/
+	static std::string getType(const std::string &filename);
+
+private:
+	MimeTypes();
+	~MimeTypes();
+
+	MimeTypes(const MimeTypes &) = delete;
+	MimeTypes &operator=(const MimeTypes &) = delete;
+
+	std::map<std::string, std::string> extensionToType;
+
+	static MimeTypes instance;
+};


### PR DESCRIPTION
Address issue #41 where file requests were always served as application/octet-stream, preventing browsers from displaying content like images or HTML.

Changes:
- **MimeTypes Singleton:** Added a static class that automatically parses `/etc/mime.types` upon application startup (static initialization).
- **Output Validation:** Updated `FileRequestHandler` to query `MimeTypes::getType()` and set the specific `Content-Type` header (e.g., `text/html`, `image/png`).
- **Robustness:** Implemented case-insensitive extension matching (supporting `.JPG` or `.HTML`) and safe fallback to `application/octet-stream` for unknown types.

Fixes #41