### PR TITLE
Fix FD leak in FileRequestHandler

### DIFF
--- a/src/FileRequestHandler.cpp
+++ b/src/FileRequestHandler.cpp
@@ -19,12 +19,6 @@ FileRequestHandler::FileRequestHandler(IRequestManager &manager, const char *fil
 	start(filePath);
 }
 
-FileRequestHandler::~FileRequestHandler()
-{
-	if (fd_ != -1)
-		close(fd_);
-}
-
 void FileRequestHandler::onBodyData(std::span<const char> /*data*/)
 {
 	// Ignore body data for GET
@@ -59,7 +53,7 @@ void FileRequestHandler::sendErrorResponse(int code, const std::string &message)
 
 void FileRequestHandler::start(const char *filePath)
 {
-	fd_ = open(filePath, O_RDONLY);
+	fd_ = UnixFD(open(filePath, O_RDONLY));
 	if (fd_ == -1)
 	{
 		if (errno == ENOENT)

--- a/src/FileRequestHandler.hpp
+++ b/src/FileRequestHandler.hpp
@@ -6,13 +6,14 @@
 
 #include "IRequestHandler.hpp"
 #include "IRequestManager.hpp"
+#include "UnixFD.hpp"
 
 class FileRequestHandler : public IRequestHandler
 {
 public:
 	// Router is expected to map and validate file path already, so we take it in the form we need for syscalls
 	FileRequestHandler(IRequestManager &manager, const char *filePath);
-	~FileRequestHandler();
+	~FileRequestHandler() = default;
 	void onBodyData(std::span<const char> data) override;
 	void onBodyDone() override;
 	void notifyResponseBuffer(size_t bufferSize) override;
@@ -20,7 +21,7 @@ public:
 private:
 	IRequestManager &manager_;
 	size_t bytesRemaining_;
-	int fd_ = -1;
+	UnixFD fd_;
 
 	void sendErrorResponse(int code, const std::string &message);
 	void start(const char *filePath);


### PR DESCRIPTION
If FileRequestHandler does not hit buffer limit, the entire file is sent within the constructor. Call to manager._onRequestDone throws an exception to bail out of request handler functions. But because the FileRequestHandler constructor never completed, its destructor is not called either, and the open file descriptor is leaked.

Fix by storing the file descriptor in a member variable type with its own destructor. Even though the containing class was never fully constructed, its member variables were, and thus will have their destructors called.