### PR TITLE
Increase listener backlog size

### DIFF
--- a/src/Listener.hpp
+++ b/src/Listener.hpp
@@ -27,6 +27,6 @@ private:
 	UnixFD fd;
 
 	// Max queue of unaccepted connections - see `man 2 listen`
-	static const int acceptBacklog = 10;
+	static const int acceptBacklog = 500;
 	void onReadable();
 };


### PR DESCRIPTION
This seems to work around a strange bug that causes unexpected TCP resets or missing initial client-sent bytes of the connection when testing with large number of new connections.

Fixes #56, hopefully.