### PR TITLE
Adjust poll result handling loop

### DIFF
--- a/src/Poll.cpp
+++ b/src/Poll.cpp
@@ -58,34 +58,42 @@ void Poll::doPoll(int timeout)
 		// Ensure the FD is still registered (it might have been by callbacks in previous iterations)
 		auto it = instance.fdMap.find(current.fd);
 		if (it == instance.fdMap.end())
-			return;
+			continue;
 
 		// 1. Handle Errors
-		if (current.revents & POLLERR)
-			if (it->second.error)
-				// This function should only be called from main, so it should be safe
-				// to do *any* delayed cleanup here
-				handleDelayedCleanup<DelayedCleanupBase>(it->second.error);
+		bool isError = current.revents & POLLERR;
+		if (isError && it->second.error)
+		{
+			// This function should only be called from main, so it should be safe
+			// to do *any* delayed cleanup here
+			handleDelayedCleanup<DelayedCleanupBase>(it->second.error);
 
-		// Check FD again after callback
-		it = instance.fdMap.find(current.fd);
-		if (it == instance.fdMap.end())
-			return;
+			// Check FD again after callback
+			it = instance.fdMap.find(current.fd);
+			if (it == instance.fdMap.end())
+				continue;
+		}
 
 		// 2. Handle Read (or Hangup)
-		if (current.revents & (POLLIN | POLLHUP))
-			if (it->second.readable)
-				handleDelayedCleanup<DelayedCleanupBase>(it->second.readable);
+		bool isReadable = current.revents & (POLLIN | POLLHUP);
+		if (isReadable && it->second.readable)
+		{
+			// This function should only be called from main, so it should be safe
+			// to do *any* delayed cleanup here
+			handleDelayedCleanup<DelayedCleanupBase>(it->second.readable);
 
-		// Check FD again after callback
-		it = instance.fdMap.find(current.fd);
-		if (it == instance.fdMap.end())
-			return;
+			// Check FD again after callback
+			it = instance.fdMap.find(current.fd);
+			if (it == instance.fdMap.end())
+				continue;
+		}
 
 		// 3. Handle Write
-		if (current.revents & POLLOUT)
-			if (it->second.writable)
-				handleDelayedCleanup<DelayedCleanupBase>(it->second.writable);
+		bool isWritable = current.revents & POLLOUT;
+		if (isWritable && it->second.writable)
+			// This function should only be called from main, so it should be safe
+			// to do *any* delayed cleanup here
+			handleDelayedCleanup<DelayedCleanupBase>(it->second.writable);
 	}
 }
 


### PR DESCRIPTION
Continue statements to skip current loop iteration were accidentally replaced with return statements, probably with the intent of replacing the entire loop body with a lambda call (which didn't happen). The return statements meant that if skipping happened, any other FDs further in the poll list would be skipped completely. The next poll would of course return immediately with the remaining file descriptors still able to make progress, but relying that is sloppy and inefficient.

While looking at the code, only perform the rechecking after callback if a callback was actually executed. For readability, remove a level of nested if statements and use a variable for first half of the condition.