### PR TITLE
Catch DelayedCleanupBase recursively in main loop elements

### DIFF
--- a/src/CallbackQueue.cpp
+++ b/src/CallbackQueue.cpp
@@ -31,7 +31,7 @@ void CallbackQueue::handleQueue()
 	{
 		// This function should only be called from main, so it should be safe
 		// to do *any* delayed cleanup here
-		handleDelayedCleanup<DelayedCleanupBase>(instance.queue[i].cb);
+		handleAllDelayedCleanup(instance.queue[i].cb);
 	}
 	instance.queue.clear();
 }

--- a/src/DelayedCleanup.hpp
+++ b/src/DelayedCleanup.hpp
@@ -62,3 +62,48 @@ void handleDelayedCleanup(Callable &&callable, Args &&...args)
 		static_cast<const DelayedCleanupBase &>(ex).cleanup();
 	}
 }
+
+/*
+	Invoke `callable` with `args` and automatically handle all delayed cleanup
+	exceptions, even if the `cleanup` function of one exception throws another.
+
+	Use a lambda for `callable` to wrap more than a single function call in the
+	same try-catch.
+*/
+template <typename Callable, typename... Args>
+	requires(std::invocable<Callable, Args...>)
+void handleAllDelayedCleanup(Callable &&callable, Args &&...args)
+{
+	/*
+		If `ex.cleanup()` throws another DelayedCleanupException, it leaks out
+		of `handleDelayedCleanup`. We want to catch and handle that exception
+		too, until no more are thrown.
+
+		The original exception object is destroyed at end of the catch block,
+		and we can't directly copy the object without knowing its actual derived
+		type, so use `std::exception_ptr` for storing it.
+
+		We can't directly access the object through `std::exception_ptr`, but
+		`std::rethrow_exception` makes it catchable again.
+	*/
+	std::exception_ptr caught;
+	do
+	{
+		try
+		{
+			if (!caught) // First iteration
+				handleDelayedCleanup<DelayedCleanupBase>(
+					std::forward<Callable>(callable),
+					std::forward<Args>(args)...);
+			else // Looped with a leaked exception
+			{
+				handleDelayedCleanup<DelayedCleanupBase>(std::rethrow_exception, caught);
+				caught = nullptr;
+			}
+		}
+		catch (const DelayedCleanupBase &ex)
+		{
+			caught = std::current_exception();
+		}
+	} while (caught);
+}

--- a/src/Poll.cpp
+++ b/src/Poll.cpp
@@ -70,7 +70,7 @@ void Poll::doPoll(int timeout)
 		{
 			// This function should only be called from main, so it should be safe
 			// to do *any* delayed cleanup here
-			handleDelayedCleanup<DelayedCleanupBase>(it->second.error);
+			handleAllDelayedCleanup(it->second.error);
 
 			// Check FD again after callback
 			it = instance.fdMap.find(current.fd);
@@ -84,7 +84,7 @@ void Poll::doPoll(int timeout)
 		{
 			// This function should only be called from main, so it should be safe
 			// to do *any* delayed cleanup here
-			handleDelayedCleanup<DelayedCleanupBase>(it->second.readable);
+			handleAllDelayedCleanup(it->second.readable);
 
 			// Check FD again after callback
 			it = instance.fdMap.find(current.fd);
@@ -97,7 +97,7 @@ void Poll::doPoll(int timeout)
 		if (isWritable && it->second.writable)
 			// This function should only be called from main, so it should be safe
 			// to do *any* delayed cleanup here
-			handleDelayedCleanup<DelayedCleanupBase>(it->second.writable);
+			handleAllDelayedCleanup(it->second.writable);
 	}
 }
 

--- a/src/Timeout.cpp
+++ b/src/Timeout.cpp
@@ -24,7 +24,7 @@ void TimeoutManager::processTimeouts()
 		entry->owner->callback = nullptr;
 		instance.queue.erase(entry);
 		if (callback)
-			handleDelayedCleanup<DelayedCleanupBase>(callback);
+			handleAllDelayedCleanup(callback);
 	}
 }
 


### PR DESCRIPTION
Delayed cleanup may sometimes throw another `DelayedCleanupException`, e.g. when request handler termination leaves connection in an unusable state. The main loop elements (poll, timeouts, callback queue) should never allow a `DelayedCleanupException` to be thrown further, so we need to also handle any thrown out of the `cleanup` function. Add `handleAllDelayedCleanup` which does this, and use that instead.