### PR TITLE
Fix FileRequestHandler for empty files

### DIFF
--- a/src/FileRequestHandler.cpp
+++ b/src/FileRequestHandler.cpp
@@ -98,10 +98,9 @@ void FileRequestHandler::sendData()
 			bytesRead = bytesRemaining_;
 		bytesRemaining_ -= bytesRead;
 		size_t bufferSize = manager_.writeResponseData(std::span(readBuffer, bytesRead));
-		if (bytesRemaining_ == 0)
-			return manager_.onRequestDone();
-		if (bufferSize >= BUFFER_LIMIT)
+		if (bytesRemaining_ && bufferSize >= BUFFER_LIMIT)
 			// buffer full, wait for notifyResponseBuffer
 			return;
 	}
+	manager_.onRequestDone();
 }


### PR DESCRIPTION
If the file is empty, the loop in FileRequestHandler::sendData is never entered, and the request was never reported as completed. Move the onRequestDone call out of the loop, and adjust the buffer full condition accordingly.